### PR TITLE
Moved label bold weighting outside of content-body

### DIFF
--- a/ui/components/forms/flavors/nds/_index-bs3.scss
+++ b/ui/components/forms/flavors/nds/_index-bs3.scss
@@ -43,10 +43,10 @@
     position: relative;
     left: $spacing-xx-small;
   }
+}
 
-  label {
-    font-weight: $font-weight-regular;
-  }
+label {
+  font-weight: $font-weight-regular;
 }
 
 .content-body {


### PR DESCRIPTION
Moved label bold weighting outside of content-label

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/loanlifecycle/design-system/26)

<!-- Reviewable:end -->
