### PR TITLE
PROD-2936 PROD-2965 / Revert "PROD 2522"

### DIFF
--- a/ui/components/nds-sections/flavors/base/_index-bs3.scss
+++ b/ui/components/nds-sections/flavors/base/_index-bs3.scss
@@ -1,6 +1,5 @@
 .body-content {
   margin-bottom: $spacing-medium;
-  z-index: $z-index-default;
 
   .content-heading {
     @include border($borders: top left right);

--- a/ui/components/tabs/flavors/nds/_index-bs3.scss
+++ b/ui/components/tabs/flavors/nds/_index-bs3.scss
@@ -6,7 +6,6 @@
   overflow: hidden;
   text-transform: capitalize;
   background: $color-background-alt;
-  z-index: $z-index-default;
 
   .item {
     @include tabs-link;


### PR DESCRIPTION
Reverts loanlifecycle/design-system#30

PROD-2936 and PROD-2965 are caused by the z-index change.
PROD-2522 also appears to be resolved w/o the z-index change now:

![screen shot 2016-10-13 at 8 33 55 am](https://cloud.githubusercontent.com/assets/12901660/19349296/4ed8ce0c-9120-11e6-8105-3f4849b60107.png)
![screen shot 2016-10-13 at 8 36 50 am](https://cloud.githubusercontent.com/assets/12901660/19349299/4fd2321c-9120-11e6-81ea-ec6f811fdc61.png)
![screen shot 2016-10-13 at 8 37 25 am](https://cloud.githubusercontent.com/assets/12901660/19349300/4fd8bd08-9120-11e6-815f-958ea37a462f.png)

To be reviewed
