### PR TITLE
PROD-4831

### DIFF
--- a/ui/components/forms/flavors/nds/_index-bs3.scss
+++ b/ui/components/forms/flavors/nds/_index-bs3.scss
@@ -3,7 +3,6 @@
   width: 100%;
   font-size: $font-size-small;
   line-height: $line-height-text;
-  white-space: nowrap;
   color: $color-text-label;
 
   [class*="fa fa-"],


### PR DESCRIPTION
remove white-space: nowrap from forms content-label. allowing content labels to wrap based on parent div width